### PR TITLE
Push Docker images to GCR instead of Codefresh

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,7 +19,7 @@ jobs:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven2-${{ hashFiles('**/pom.xml') }}
       - name: Docker login
-        run: docker login eu.gcr.io --username fropenbanking --password ${{ secrets.CODEFRESH_DOCKER_REGISTRY_API_KEY }}
+        run :echo "${{ secrets.GCR_JSON_KEY }}" | docker login eu.gcr.io -u _json_key --password-stdin
 
       - name: Check Copyright
         run: mvn license:check

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,7 +19,7 @@ jobs:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven2-${{ hashFiles('**/pom.xml') }}
       - name: Docker login
-        run: docker login r.cfcr.io --username fropenbanking --password ${{ secrets.CODEFRESH_DOCKER_REGISTRY_API_KEY }}
+        run: docker login eu.gcr.io --username fropenbanking --password ${{ secrets.CODEFRESH_DOCKER_REGISTRY_API_KEY }}
 
       - name: Check Copyright
         run: mvn license:check

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,7 +19,7 @@ jobs:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven2-${{ hashFiles('**/pom.xml') }}
       - name: Docker login
-        run :echo "${{ secrets.GCR_JSON_KEY }}" | docker login eu.gcr.io -u _json_key --password-stdin
+        run: echo "${{ secrets.GCR_JSON_KEY }}" | docker login eu.gcr.io -u _json_key --password-stdin
 
       - name: Check Copyright
         run: mvn license:check

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,7 +19,7 @@ jobs:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven2-${{ hashFiles('**/pom.xml') }}
       - name: Docker login
-        run: echo "${{ secrets.GCR_JSON_KEY }}" | docker login eu.gcr.io -u _json_key --password-stdin
+        run: echo "${{ secrets.GCR_JSON_KEY_BASE64 }}" | base64 -d | docker login eu.gcr.io -u _json_key --password-stdin
 
       - name: Check Copyright
         run: mvn license:check

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -54,7 +54,7 @@ jobs:
         run: |
           export BUILD_VERSION=$(jq -r ".project_version" package.json)-${GITHUB_SHA::7}
           echo "Building docker image eu.gcr.io/openbanking-214714/obri/tpp-node:${BUILD_VERSION}"
-          echo ${{ secrets.GCR_JSON_KEY }} | docker login eu.gcr.io -u _json_key --password-stdin
+          echo "${{ secrets.GCR_JSON_KEY }}" | docker login eu.gcr.io -u _json_key --password-stdin
           docker build -f projects/tpp/docker/Dockerfile-server -t eu.gcr.io/openbanking-214714/obri/tpp-node:$BUILD_VERSION .
           docker push eu.gcr.io/openbanking-214714/obri/tpp-node:$BUILD_VERSION
   build_tpp_ui:
@@ -81,7 +81,7 @@ jobs:
         run: |
           export BUILD_VERSION=$(jq -r ".project_version" package.json)-${GITHUB_SHA::7}
           echo "Building docker image eu.gcr.io/openbanking-214714/obri/tpp-ui:${BUILD_VERSION}"
-          echo ${{ secrets.GCR_JSON_KEY }} | docker login eu.gcr.io -u _json_key --password-stdin
+          echo "${{ secrets.GCR_JSON_KEY }}" | docker login eu.gcr.io -u _json_key --password-stdin
           docker build -f projects/tpp/docker/Dockerfile -t eu.gcr.io/openbanking-214714/obri/tpp-ui:$BUILD_VERSION .
           docker push eu.gcr.io/openbanking-214714/obri/tpp-ui:$BUILD_VERSION
   update_ob_deploy:

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -54,7 +54,7 @@ jobs:
         run: |
           export BUILD_VERSION=$(jq -r ".project_version" package.json)-${GITHUB_SHA::7}
           echo "Building docker image eu.gcr.io/openbanking-214714/obri/tpp-node:${BUILD_VERSION}"
-          docker login eu.gcr.io -u _json_key -p ${{ secrets.GCR_JSON_KEY }}
+          echo ${{ secrets.GCR_JSON_KEY }} | docker login eu.gcr.io -u _json_key --password-stdin
           docker build -f projects/tpp/docker/Dockerfile-server -t eu.gcr.io/openbanking-214714/obri/tpp-node:$BUILD_VERSION .
           docker push eu.gcr.io/openbanking-214714/obri/tpp-node:$BUILD_VERSION
   build_tpp_ui:
@@ -81,7 +81,7 @@ jobs:
         run: |
           export BUILD_VERSION=$(jq -r ".project_version" package.json)-${GITHUB_SHA::7}
           echo "Building docker image eu.gcr.io/openbanking-214714/obri/tpp-ui:${BUILD_VERSION}"
-          docker login eu.gcr.io -u _json_key -p ${{ secrets.GCR_JSON_KEY }}
+          echo ${{ secrets.GCR_JSON_KEY }} | docker login eu.gcr.io -u _json_key --password-stdin
           docker build -f projects/tpp/docker/Dockerfile -t eu.gcr.io/openbanking-214714/obri/tpp-ui:$BUILD_VERSION .
           docker push eu.gcr.io/openbanking-214714/obri/tpp-ui:$BUILD_VERSION
   update_ob_deploy:

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -54,7 +54,7 @@ jobs:
         run: |
           export BUILD_VERSION=$(jq -r ".project_version" package.json)-${GITHUB_SHA::7}
           echo "Building docker image eu.gcr.io/openbanking-214714/obri/tpp-node:${BUILD_VERSION}"
-          echo "${{ secrets.GCR_JSON_KEY }}" | docker login eu.gcr.io -u _json_key --password-stdin
+          echo "${{ secrets.GCR_JSON_KEY_BASE64 }}" | base64 -d | docker login eu.gcr.io -u _json_key --password-stdin
           docker build -f projects/tpp/docker/Dockerfile-server -t eu.gcr.io/openbanking-214714/obri/tpp-node:$BUILD_VERSION .
           docker push eu.gcr.io/openbanking-214714/obri/tpp-node:$BUILD_VERSION
   build_tpp_ui:
@@ -81,7 +81,7 @@ jobs:
         run: |
           export BUILD_VERSION=$(jq -r ".project_version" package.json)-${GITHUB_SHA::7}
           echo "Building docker image eu.gcr.io/openbanking-214714/obri/tpp-ui:${BUILD_VERSION}"
-          echo "${{ secrets.GCR_JSON_KEY }}" | docker login eu.gcr.io -u _json_key --password-stdin
+          echo "${{ secrets.GCR_JSON_KEY_BASE64 }}" | base64 -d | docker login eu.gcr.io -u _json_key --password-stdin
           docker build -f projects/tpp/docker/Dockerfile -t eu.gcr.io/openbanking-214714/obri/tpp-ui:$BUILD_VERSION .
           docker push eu.gcr.io/openbanking-214714/obri/tpp-ui:$BUILD_VERSION
   update_ob_deploy:

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -53,10 +53,10 @@ jobs:
         working-directory: ./forgerock-openbanking-ui
         run: |
           export BUILD_VERSION=$(jq -r ".project_version" package.json)-${GITHUB_SHA::7}
-          echo "Building docker image r.cfcr.io/openbanking/obri/tpp-node:${BUILD_VERSION}"
-          docker login r.cfcr.io -u fropenbanking -p ${{ secrets.CODEFRESH_DOCKER_REGISTRY_API_KEY }}
-          docker build -f projects/tpp/docker/Dockerfile-server -t r.cfcr.io/openbanking/obri/tpp-node:$BUILD_VERSION .
-          docker push r.cfcr.io/openbanking/obri/tpp-node:$BUILD_VERSION
+          echo "Building docker image eu.gcr.io/openbanking/obri/tpp-node:${BUILD_VERSION}"
+          docker login eu.gcr.io -u _json_key -p ${{ secrets.GCR_JSON_KEY }}
+          docker build -f projects/tpp/docker/Dockerfile-server -t eu.gcr.io/openbanking/obri/tpp-node:$BUILD_VERSION .
+          docker push eu.gcr.io/openbanking/obri/tpp-node:$BUILD_VERSION
   build_tpp_ui:
     name: Build TPP App
     runs-on: ubuntu-latest
@@ -80,10 +80,10 @@ jobs:
         working-directory: ./forgerock-openbanking-ui
         run: |
           export BUILD_VERSION=$(jq -r ".project_version" package.json)-${GITHUB_SHA::7}
-          echo "Building docker image r.cfcr.io/openbanking/obri/tpp-ui:${BUILD_VERSION}"
-          docker login r.cfcr.io -u fropenbanking -p ${{ secrets.CODEFRESH_DOCKER_REGISTRY_API_KEY }}
-          docker build -f projects/tpp/docker/Dockerfile -t r.cfcr.io/openbanking/obri/tpp-ui:$BUILD_VERSION .
-          docker push r.cfcr.io/openbanking/obri/tpp-ui:$BUILD_VERSION
+          echo "Building docker image eu.gcr.io/openbanking/obri/tpp-ui:${BUILD_VERSION}"
+          docker login eu.gcr.io -u _json_key -p ${{ secrets.GCR_JSON_KEY }}
+          docker build -f projects/tpp/docker/Dockerfile -t eu.gcr.io/openbanking/obri/tpp-ui:$BUILD_VERSION .
+          docker push eu.gcr.io/openbanking/obri/tpp-ui:$BUILD_VERSION
   update_ob_deploy:
     name: Update ob-deploy
     runs-on: ubuntu-latest

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -53,10 +53,10 @@ jobs:
         working-directory: ./forgerock-openbanking-ui
         run: |
           export BUILD_VERSION=$(jq -r ".project_version" package.json)-${GITHUB_SHA::7}
-          echo "Building docker image eu.gcr.io/openbanking/obri/tpp-node:${BUILD_VERSION}"
+          echo "Building docker image eu.gcr.io/openbanking-214714/obri/tpp-node:${BUILD_VERSION}"
           docker login eu.gcr.io -u _json_key -p ${{ secrets.GCR_JSON_KEY }}
-          docker build -f projects/tpp/docker/Dockerfile-server -t eu.gcr.io/openbanking/obri/tpp-node:$BUILD_VERSION .
-          docker push eu.gcr.io/openbanking/obri/tpp-node:$BUILD_VERSION
+          docker build -f projects/tpp/docker/Dockerfile-server -t eu.gcr.io/openbanking-214714/obri/tpp-node:$BUILD_VERSION .
+          docker push eu.gcr.io/openbanking-214714/obri/tpp-node:$BUILD_VERSION
   build_tpp_ui:
     name: Build TPP App
     runs-on: ubuntu-latest
@@ -80,10 +80,10 @@ jobs:
         working-directory: ./forgerock-openbanking-ui
         run: |
           export BUILD_VERSION=$(jq -r ".project_version" package.json)-${GITHUB_SHA::7}
-          echo "Building docker image eu.gcr.io/openbanking/obri/tpp-ui:${BUILD_VERSION}"
+          echo "Building docker image eu.gcr.io/openbanking-214714/obri/tpp-ui:${BUILD_VERSION}"
           docker login eu.gcr.io -u _json_key -p ${{ secrets.GCR_JSON_KEY }}
-          docker build -f projects/tpp/docker/Dockerfile -t eu.gcr.io/openbanking/obri/tpp-ui:$BUILD_VERSION .
-          docker push eu.gcr.io/openbanking/obri/tpp-ui:$BUILD_VERSION
+          docker build -f projects/tpp/docker/Dockerfile -t eu.gcr.io/openbanking-214714/obri/tpp-ui:$BUILD_VERSION .
+          docker push eu.gcr.io/openbanking-214714/obri/tpp-ui:$BUILD_VERSION
   update_ob_deploy:
     name: Update ob-deploy
     runs-on: ubuntu-latest


### PR DESCRIPTION
Push/pull Docker images to/from GCR instead of Codefresh. This references a new Github secret called `GCR_JSON_KEY` which is a new access token for Google Cloud with a limited scope for the container registry.

Part of https://github.com/ForgeCloud/ob-deploy/issues/468