### PR TITLE
Use the version 1.0.78 of openbanking-commons 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <url>http://www.forgerock.org</url>
 
     <properties>
-        <ob-common.version>1.0.77</ob-common.version>
+        <ob-common.version>1.0.78</ob-common.version>
         <ob-auth.version>1.0.59</ob-auth.version>
         <ob-jwkms.version>1.1.71</ob-jwkms.version>
         <ob-clients.version>1.0.36</ob-clients.version>


### PR DESCRIPTION
openbanking-commons has a UI project in it and needs it's project_version set so that the ui-template docker images have the correct version names.