### PR TITLE
Fix missing analytics entries use 1.0.41 of ob clients

### DIFF
--- a/forgerock-openbanking-tpp-account/pom.xml
+++ b/forgerock-openbanking-tpp-account/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.tpp</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-tpp</artifactId>
-        <version>1.0.58</version>
+        <version>1.0.59-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-tpp-account/pom.xml
+++ b/forgerock-openbanking-tpp-account/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.tpp</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-tpp</artifactId>
-        <version>1.0.58-SNAPSHOT</version>
+        <version>1.0.58</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-tpp-core/pom.xml
+++ b/forgerock-openbanking-tpp-core/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.tpp</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-tpp</artifactId>
-	<version>1.0.58</version>
+	<version>1.0.59-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-tpp-core/pom.xml
+++ b/forgerock-openbanking-tpp-core/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.tpp</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-tpp</artifactId>
-	<version>1.0.58-SNAPSHOT</version>
+	<version>1.0.58</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-tpp-model/pom.xml
+++ b/forgerock-openbanking-tpp-model/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.tpp</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-tpp</artifactId>
-        <version>1.0.58</version>
+        <version>1.0.59-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-tpp-model/pom.xml
+++ b/forgerock-openbanking-tpp-model/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.tpp</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-tpp</artifactId>
-        <version>1.0.58-SNAPSHOT</version>
+        <version>1.0.58</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-tpp-shop/pom.xml
+++ b/forgerock-openbanking-tpp-shop/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.tpp</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-tpp</artifactId>
-        <version>1.0.58</version>
+        <version>1.0.59-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-tpp-shop/pom.xml
+++ b/forgerock-openbanking-tpp-shop/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.tpp</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-tpp</artifactId>
-        <version>1.0.58-SNAPSHOT</version>
+        <version>1.0.58</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-ui/package.json
+++ b/forgerock-openbanking-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forgerock-openbanking-ui",
-  "project_version": "3.1.6-rem-rc1",
+  "project_version": "3.1.6-smiths-rc1",
   "version": "1.0.0",
   "scripts": {
     "ng": "ng",

--- a/forgerock-openbanking-ui/pom.xml
+++ b/forgerock-openbanking-ui/pom.xml
@@ -30,7 +30,7 @@
   <parent>
     <groupId>com.forgerock.openbanking.tpp</groupId>
     <artifactId>forgerock-openbanking-reference-implementation-tpp</artifactId>
-    <version>1.0.58</version>
+    <version>1.0.59-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/forgerock-openbanking-ui/pom.xml
+++ b/forgerock-openbanking-ui/pom.xml
@@ -30,7 +30,7 @@
   <parent>
     <groupId>com.forgerock.openbanking.tpp</groupId>
     <artifactId>forgerock-openbanking-reference-implementation-tpp</artifactId>
-    <version>1.0.58-SNAPSHOT</version>
+    <version>1.0.58</version>
   </parent>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -45,9 +45,9 @@
 
     <properties>
         <ob-common.version>1.0.81</ob-common.version>
-        <ob-auth.version>1.0.62</ob-auth.version>
-        <ob-jwkms.version>1.1.73</ob-jwkms.version>
-        <ob-clients.version>1.0.40</ob-clients.version>
+        <ob-auth.version>1.0.63</ob-auth.version>
+        <ob-jwkms.version>1.1.75</ob-jwkms.version>
+        <ob-clients.version>1.0.41</ob-clients.version>
     </properties>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Reference Implementation - TPP</name>
     <groupId>com.forgerock.openbanking.tpp</groupId>
     <artifactId>forgerock-openbanking-reference-implementation-tpp</artifactId>
-    <version>1.0.58-SNAPSHOT</version>
+    <version>1.0.58</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -119,7 +119,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-tpp.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-tpp.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-tpp.git</url>
-        <tag>forgerock-openbanking-reference-implementation-tpp-1.0.21</tag>
+        <tag>1.0.58</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Reference Implementation - TPP</name>
     <groupId>com.forgerock.openbanking.tpp</groupId>
     <artifactId>forgerock-openbanking-reference-implementation-tpp</artifactId>
-    <version>1.0.58</version>
+    <version>1.0.59-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -119,7 +119,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-tpp.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-tpp.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-tpp.git</url>
-        <tag>1.0.58</tag>
+        <tag>forgerock-openbanking-reference-implementation-tpp-1.0.21</tag>
     </scm>
 
     <distributionManagement>


### PR DESCRIPTION
Use latests versions of ob libs that use version 1.0.41 of openbanking
clients which contains a fix

Part fix for OpenBankingToolkit/openbanking-analytics#163