### PR TITLE
27: upgrade datatype countrySubDivision

### DIFF
--- a/forgerock-openbanking-tpp-shop/src/main/java/com/forgerock/openbanking/tpp/shop/pisp/PISPService.java
+++ b/forgerock-openbanking-tpp-shop/src/main/java/com/forgerock/openbanking/tpp/shop/pisp/PISPService.java
@@ -137,7 +137,7 @@ public class PISPService {
                         .buildingNumber(buildingNumber)
                         .postCode(postCode)
                         .townName(townName)
-                        .countrySubDivision(Arrays.asList(countySubDivision))
+                        .countrySubDivision(countySubDivision)
                         .country(country)
                 );
     }

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-parent</artifactId>
-        <version>1.1.86</version>
+        <version>1.1.88</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
 
@@ -44,10 +44,10 @@
     <url>http://www.forgerock.org</url>
 
     <properties>
-        <ob-common.version>1.1.0</ob-common.version>
-        <ob-auth.version>1.0.67</ob-auth.version>
-        <ob-jwkms.version>1.1.78</ob-jwkms.version>
-        <ob-clients.version>1.1.0</ob-clients.version>
+        <ob-common.version>1.1.1</ob-common.version>
+        <ob-auth.version>1.0.68</ob-auth.version>
+        <ob-jwkms.version>1.1.79</ob-jwkms.version>
+        <ob-clients.version>1.1.1</ob-clients.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
- Fix `countrySubDivision` in `PISPService`
- Bumped [starter parent](https://github.com/OpenBankingToolkit/openbanking-parent) version 1.1.88
- Bumped [commons](https://github.com/OpenBankingToolkit/openbanking-common) version 1.1.1
- Bumped [clients](https://github.com/OpenBankingToolkit/openbanking-clients) version 1.1.1
- Bumped [auth](https://github.com/OpenBankingToolkit/openbanking-auth) version 1.0.68
- Bumped [jwkms](https://github.com/OpenBankingToolkit/openbanking-jwkms) version 1.1.79

Issue: https://github.com/OpenBankingToolkit/openbanking-toolkit/issues/27