### PR TITLE
Release 1.1.8 with 796: add matls checks to dcr code

### DIFF
--- a/forgerock-openbanking-tpp-account/pom.xml
+++ b/forgerock-openbanking-tpp-account/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.tpp</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-tpp</artifactId>
-        <version>1.1.8-SNAPSHOT</version>
+        <version>1.1.8</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-tpp-account/pom.xml
+++ b/forgerock-openbanking-tpp-account/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.tpp</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-tpp</artifactId>
-        <version>1.1.8</version>
+        <version>1.1.9-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-tpp-core/pom.xml
+++ b/forgerock-openbanking-tpp-core/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.tpp</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-tpp</artifactId>
-	<version>1.1.8</version>
+	<version>1.1.9-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-tpp-core/pom.xml
+++ b/forgerock-openbanking-tpp-core/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.tpp</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-tpp</artifactId>
-	<version>1.1.8-SNAPSHOT</version>
+	<version>1.1.8</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-tpp-model/pom.xml
+++ b/forgerock-openbanking-tpp-model/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.tpp</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-tpp</artifactId>
-        <version>1.1.8-SNAPSHOT</version>
+        <version>1.1.8</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-tpp-model/pom.xml
+++ b/forgerock-openbanking-tpp-model/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.tpp</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-tpp</artifactId>
-        <version>1.1.8</version>
+        <version>1.1.9-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-tpp-shop/pom.xml
+++ b/forgerock-openbanking-tpp-shop/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.tpp</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-tpp</artifactId>
-        <version>1.1.8-SNAPSHOT</version>
+        <version>1.1.8</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-tpp-shop/pom.xml
+++ b/forgerock-openbanking-tpp-shop/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.tpp</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-tpp</artifactId>
-        <version>1.1.8</version>
+        <version>1.1.9-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -44,10 +44,10 @@
     <url>http://www.forgerock.org</url>
 
     <properties>
-        <ob-common.version>1.2.9</ob-common.version>
-        <ob-clients.version>1.2.9</ob-clients.version>
-        <ob-jwkms.version>1.2.8</ob-jwkms.version>
-        <ob-auth.version>1.1.8</ob-auth.version>
+        <ob-common.version>1.2.10</ob-common.version>
+        <ob-clients.version>1.2.10</ob-clients.version>
+        <ob-jwkms.version>1.2.9</ob-jwkms.version>
+        <ob-auth.version>1.1.9</ob-auth.version>
     </properties>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Reference Implementation - TPP</name>
     <groupId>com.forgerock.openbanking.tpp</groupId>
     <artifactId>forgerock-openbanking-reference-implementation-tpp</artifactId>
-    <version>1.1.8-SNAPSHOT</version>
+    <version>1.1.8</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -118,7 +118,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-tpp.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-tpp.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-tpp.git</url>
-        <tag>forgerock-openbanking-reference-implementation-tpp-1.0.21</tag>
+        <tag>1.1.8</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Reference Implementation - TPP</name>
     <groupId>com.forgerock.openbanking.tpp</groupId>
     <artifactId>forgerock-openbanking-reference-implementation-tpp</artifactId>
-    <version>1.1.8</version>
+    <version>1.1.9-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -118,7 +118,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-tpp.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-tpp.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-tpp.git</url>
-        <tag>1.1.8</tag>
+        <tag>forgerock-openbanking-reference-implementation-tpp-1.0.21</tag>
     </scm>
 
     <distributionManagement>


### PR DESCRIPTION
796: Add MATLS checks to DCR code

Common code needed to perform MATLS checks to ensure the MATLS transport
cert presented for registration and the software statement being used
for registration were issed to the same ApiClient (TPP)

Issue: https://github.com/ForgeCloud/ob-deploy/issues/796