### PR TITLE
Release 1.1.10 and Use latest parent and commons

### DIFF
--- a/forgerock-openbanking-tpp-account/pom.xml
+++ b/forgerock-openbanking-tpp-account/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.tpp</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-tpp</artifactId>
-        <version>1.1.10</version>
+        <version>1.1.11-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-tpp-core/pom.xml
+++ b/forgerock-openbanking-tpp-core/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.tpp</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-tpp</artifactId>
-	<version>1.1.10</version>
+	<version>1.1.11-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-tpp-model/pom.xml
+++ b/forgerock-openbanking-tpp-model/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.tpp</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-tpp</artifactId>
-        <version>1.1.10</version>
+        <version>1.1.11-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-tpp-shop/pom.xml
+++ b/forgerock-openbanking-tpp-shop/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.tpp</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-tpp</artifactId>
-        <version>1.1.10</version>
+        <version>1.1.11-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Reference Implementation - TPP</name>
     <groupId>com.forgerock.openbanking.tpp</groupId>
     <artifactId>forgerock-openbanking-reference-implementation-tpp</artifactId>
-    <version>1.1.10</version>
+    <version>1.1.11-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -118,7 +118,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-tpp.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-tpp.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-tpp.git</url>
-        <tag>1.1.10</tag>
+        <tag>forgerock-openbanking-reference-implementation-tpp-1.0.21</tag>
     </scm>
 
     <distributionManagement>


### PR DESCRIPTION
Allow creation of OBRIRoles from PSD2Role
Also;
Pulls in 1.0.3 of spring-security-mult-auth that has improved logging

Issue: ForgeCloud/ob-deploy#802