### PR TITLE
45: Release 1.1.13 and use latest uk datamodel

### DIFF
--- a/forgerock-openbanking-tpp-account/pom.xml
+++ b/forgerock-openbanking-tpp-account/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.tpp</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-tpp</artifactId>
-        <version>1.1.12-SNAPSHOT</version>
+        <version>1.1.12</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-tpp-account/pom.xml
+++ b/forgerock-openbanking-tpp-account/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.tpp</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-tpp</artifactId>
-        <version>1.1.12</version>
+        <version>1.1.13-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-tpp-core/pom.xml
+++ b/forgerock-openbanking-tpp-core/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.tpp</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-tpp</artifactId>
-	<version>1.1.12</version>
+	<version>1.1.13-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-tpp-core/pom.xml
+++ b/forgerock-openbanking-tpp-core/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.tpp</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-tpp</artifactId>
-	<version>1.1.12-SNAPSHOT</version>
+	<version>1.1.12</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-tpp-model/pom.xml
+++ b/forgerock-openbanking-tpp-model/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.tpp</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-tpp</artifactId>
-        <version>1.1.12-SNAPSHOT</version>
+        <version>1.1.12</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-tpp-model/pom.xml
+++ b/forgerock-openbanking-tpp-model/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.tpp</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-tpp</artifactId>
-        <version>1.1.12</version>
+        <version>1.1.13-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-tpp-shop/pom.xml
+++ b/forgerock-openbanking-tpp-shop/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.tpp</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-tpp</artifactId>
-        <version>1.1.12-SNAPSHOT</version>
+        <version>1.1.12</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-tpp-shop/pom.xml
+++ b/forgerock-openbanking-tpp-shop/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.tpp</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-tpp</artifactId>
-        <version>1.1.12</version>
+        <version>1.1.13-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Reference Implementation - TPP</name>
     <groupId>com.forgerock.openbanking.tpp</groupId>
     <artifactId>forgerock-openbanking-reference-implementation-tpp</artifactId>
-    <version>1.1.12-SNAPSHOT</version>
+    <version>1.1.12</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -118,7 +118,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-tpp.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-tpp.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-tpp.git</url>
-        <tag>forgerock-openbanking-reference-implementation-tpp-1.0.21</tag>
+        <tag>1.1.12</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-parent</artifactId>
-        <version>1.2.5</version>
+        <version>1.2.6</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
 
@@ -44,10 +44,10 @@
     <url>http://www.forgerock.org</url>
 
     <properties>
-        <ob-common.version>1.2.13</ob-common.version>
-        <ob-clients.version>1.2.13</ob-clients.version>
-        <ob-jwkms.version>1.2.12</ob-jwkms.version>
-        <ob-auth.version>1.1.12</ob-auth.version>
+        <ob-common.version>1.2.14</ob-common.version>
+        <ob-clients.version>1.2.14</ob-clients.version>
+        <ob-jwkms.version>1.2.13</ob-jwkms.version>
+        <ob-auth.version>1.1.13</ob-auth.version>
     </properties>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Reference Implementation - TPP</name>
     <groupId>com.forgerock.openbanking.tpp</groupId>
     <artifactId>forgerock-openbanking-reference-implementation-tpp</artifactId>
-    <version>1.1.12</version>
+    <version>1.1.13-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -118,7 +118,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-tpp.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-tpp.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-tpp.git</url>
-        <tag>1.1.12</tag>
+        <tag>forgerock-openbanking-reference-implementation-tpp-1.0.21</tag>
     </scm>
 
     <distributionManagement>


### PR DESCRIPTION
45: Use fixed uk-datamodel for 3.1.8

OBFundsConfirmationConsentResponse1Data uses OBExternalRequestStatus1Code rather than the StatusEnum
defined within the class.

Issue: https://github.com/OpenBankingToolkit/openbanking-toolkit/issues/45